### PR TITLE
Prevent from crashing when username is empty and 'strictSSL' is false

### DIFF
--- a/index.js
+++ b/index.js
@@ -9,7 +9,7 @@ var _tools = require('graphdat-plugin-tools');
 var _previous = {};
 
 // if we have a name and password, then add an auth header
-var _httpOptions;
+var _httpOptions = {};
 if (_param.username)
     _httpOptions = { auth: { user: _param.username, pass: _param.password, sendImmediately: true }};
 


### PR DESCRIPTION
If _param.strictSSL is false, it tries to set an option on _httpOptions, but _httpOptions is still undefined at that point. This is solved by making _httpOptions an empty object